### PR TITLE
Temporary fix for bug: Loaded Share URL does not render Hi-C Map

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,7 +20,7 @@ import TraceNavigator from './traceNavigator.js'
 import IGVPanel from "./IGVPanel.js";
 import JuiceboxPanel from "./juicebox/juiceboxPanel.js";
 import { appleCrayonColorRGB255, appleCrayonColorThreeJS, highlightColor } from "./utils/colorUtils.js";
-import {getUrlParams, loadSessionURL, toJSON, loadSession, uncompressSession} from "./spacewalkSession.js"
+import {getUrlParams, loadSpacewalkSessionURL, toJSON, loadSession, uncompressSession} from "./spacewalkSession.js"
 import { initializeMaterialLibrary } from "./utils/materialLibrary.js";
 import RenderContainerController from "./renderContainerController.js";
 import {createSpacewalkFileLoaders} from './spacewalkFileLoad.js'
@@ -151,7 +151,13 @@ const initializationHelper = async container => {
     const settingsButton = document.querySelector('#spacewalk-threejs-settings-button-container')
     guiManager = new GUIManager({ settingsButton, $panel: $('#spacewalk_ui_manager_panel') });
 
-    await loadSessionURL(spacewalkSessionURL)
+    await loadSpacewalkSessionURL(spacewalkSessionURL)
+
+    // TODO: HACK HACK to ensure Hi-C map renders properly when loading a share URL
+    //       Fix by refactoring entire session URL loading scheme
+    if (juiceboxPanel.browser.dataset){
+        await juiceboxPanel.browser.contactMatrixView.repaint()
+    }
 
     document.querySelector('.navbar').style.display = 'flex'
 
@@ -162,11 +168,6 @@ const initializationHelper = async container => {
 }
 
 async function createButtonsPanelsModals(container, igvSessionURL, juiceboxSessionURL, distanceThreshold, locusString) {
-
-    // $('.checkbox-menu').on("change", "input[type='checkbox']", () => $(this).closest("li").toggleClass("active", this.checked))
-
-    // to support Viewers navbar item. Checkbox settings.
-    // $(document).on('click', '.allow-focus', e => e.stopPropagation())
 
     traceSelect = new TraceSelect()
 

--- a/js/spacewalkSession.js
+++ b/js/spacewalkSession.js
@@ -6,7 +6,7 @@ import SpacewalkEventBus from './spacewalkEventBus.js'
 import {defaultDistanceThreshold} from './juicebox/liveContactMapService.js'
 import { shortenURL } from "./share/shareHelper.js"
 
-const loadSessionURL = async spacewalkSessionURL => {
+async function loadSpacewalkSessionURL(spacewalkSessionURL){
 
     if (spacewalkSessionURL) {
         const spacewalk = JSON.parse( uncompressSession(spacewalkSessionURL) )
@@ -232,4 +232,4 @@ function uncompressSession(url) {
     }
 }
 
-export { getShareURL, getUrlParams, loadSessionURL, toJSON, loadSession, uncompressSession };
+export { getShareURL, getUrlParams, loadSpacewalkSessionURL, toJSON, loadSession, uncompressSession };


### PR DESCRIPTION
Issue when loading a share URL that incudes a Juicebox Panel with a Hi-C map. While the map does load it is not rendered. This fix (hack) addresses this. 

TODO: Refactor share url loading to piggyback on loading a session JSON file.
